### PR TITLE
Use "q" query param instead of /:query route ; /genotypes return all columns of parentage file

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,26 +235,34 @@ Essex ==	( ( S-100 , C.N.S. ) , ( ( Roanoke , ( ( Tokyo , PI 54610 ) , C.N.S. ) 
 
 The api.pl script uses the [Mojolicious](https://mojolicious.org/) library to provide a simple REST API for parentage_report.pl:
 
-```
-./api.pl daemon # development mode; for production: daemon -m production
-```
-
 An HTTP `GET /genotypes` request will return a JSON array of all genotypes that can be used as a query:
 
 ```
-curl -Sfs http://localhost:3000/genotypes
+perl api.pl get /genotypes
 ```
 
-An HTTP `GET /<query>` request will return a JSON response for the query; e.g., in another terminal:
+An HTTP `GET /?q=<query>` request will return a JSON response for the query:
 
 ```
-curl -Sfs http://localhost:3000/Essex
+perl api.pl get '/?q=Essex'
 ```
 
 Appending '/pedigree.helium.zip' will produce a zip file in a format compatible with the [Helium](https://helium.hutton.ac.uk/) pedigree viewer:
 
 ```
-curl -Sfs http://localhost:3000/Essex/pedigree.helium.zip
+perl api.pl get '/pedigree.helium.zip?q=Essex' > pedigree.helium.zip
 ```
 
 If this API is served from a public web server, the zip file can be imported directly by the Helium public web server (entering the URL in the Helium "Import > "Load Pedigree > Germinate Link" menu).
+
+To start a [Mojo::Server::Daemon](https://docs.mojolicious.org/Mojo/Server/Daemon) listening on default port 3000:
+
+```
+perl api.pl daemon # development mode; for production: daemon -m production
+```
+
+Then queries can be tested, e.g., with curl:
+
+```
+curl -f 'http://localhost:3000/?q=Essex'
+```

--- a/api.pl
+++ b/api.pl
@@ -16,9 +16,10 @@ get '/genotypes' => sub ($c) {
   return $c->render(json => \@genotypes);
 };
 
-get '/#query' => sub ($c) {
+get '/' => sub ($c) {
   my $parentage_report;
-  my $query = $c->param('query');
+  my $query = $c->param('q');
+  $c->render(text => 'query parameter q not specified', status => 422) and return if not defined($query);
   open(my $pipe, '-|', 'perl', 'parentage_report.pl', '-query', $query);
   $parentage_report = <$pipe>;
   if ($parentage_report eq "")  {
@@ -28,8 +29,9 @@ get '/#query' => sub ($c) {
   }
 };
 
-get '/#query/pedigree.helium.zip' => sub ($c) {
-  my $query = $c->param('query');
+get '/pedigree.helium.zip' => sub ($c) {
+  my $query = $c->param('q');
+  $c->render(text => 'query parameter q not specified', status => 422) and return if not defined($query);
   my $zipfile;
   open(my $table, '-|', 'perl', 'parentage_report.pl', '-table', '-query', $query);
   zip $table => \$zipfile, Name => 'pedigree.helium';

--- a/api.pl
+++ b/api.pl
@@ -5,9 +5,11 @@ use Mojolicious::Lite -signatures;
 get '/genotypes' => sub ($c) {
   open(my $fh, '<', 'data/parentage.tsv');
   my @genotypes;
-
+  <$fh>; # discard first line
   while (my $line = <$fh>) {
-    push(@genotypes, (split(/\t/, $line))[0]);
+    chomp($line);
+    my @fields = map($_ eq '' ? undef : $_, split(/\t/, $line, -1));
+    push(@genotypes, \@fields);
   }
 
   close($fh);

--- a/api.pl
+++ b/api.pl
@@ -16,7 +16,7 @@ get '/genotypes' => sub ($c) {
   return $c->render(json => \@genotypes);
 };
 
-get '/:query' => sub ($c) {
+get '/#query' => sub ($c) {
   my $parentage_report;
   my $query = $c->param('query');
   open(my $pipe, '-|', 'perl', 'parentage_report.pl', '-query', $query);
@@ -28,7 +28,7 @@ get '/:query' => sub ($c) {
   }
 };
 
-get '/:query/pedigree.helium.zip' => sub ($c) {
+get '/#query/pedigree.helium.zip' => sub ($c) {
   my $query = $c->param('query');
   my $zipfile;
   open(my $table, '-|', 'perl', 'parentage_report.pl', '-table', '-query', $query);


### PR DESCRIPTION
Fixes #8 

/genotypes API endpoint now returns all three columns of parentage.tsv (`null` for an empty column), and skips the first (header) row

Specify query in "q" query parameter to handle "/" character